### PR TITLE
add GitHub Action to lint Dockerfiles

### DIFF
--- a/.github/workflows/hadolint-analysis.yml
+++ b/.github/workflows/hadolint-analysis.yml
@@ -1,0 +1,18 @@
+name: "Dockerfile-Linting"
+
+on:
+  pull_request:
+    branches: 
+    - master
+    paths:
+    - '**/Dockerfile'
+
+jobs:
+  verification:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Pull HaDoLint image
+      run: docker pull hadolint/hadolint
+    - name: Lint Dockerfile
+      run: docker run --rm --interactive hadolint/hadolint < ./Dockerfile


### PR DESCRIPTION
same as in https://github.com/corona-warn-app/cwa-server/pull/218

> [HaDoLint](https://github.com/hadolint/hadolint) is an easy-to-use tool to verify `Dockerfiles` and thus avoid common issues.
> 
> This PR adds a GH action to use HaDoLint that is only triggered if a `Dockerfile` is changed.