### PR TITLE
remove WORKDIR from Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . ${WORK_DIR}/
 
 RUN mkdir -p /root/.m2 /usr/tsi/verification-server
 # hadolint ignore=SC2086
-RUN mvn --batch-mode --file ${WORK_DIR}/pom.xml ${MAVEN_ARGS}  install
+RUN mvn --batch-mode --file ${WORK_DIR}/pom.xml ${MAVEN_ARGS} install
 RUN cp ${WORK_DIR}/target/cwa-verification-server*.jar /usr/tsi/verification-server/verification.jar
 
 FROM gcr.io/distroless/java:11

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@ FROM maven:3.6.3-jdk-11 as build
 ARG WORK_DIR=/build
 
 COPY . ${WORK_DIR}/
-WORKDIR ${WORK_DIR}
 
 RUN mkdir -p /root/.m2 /usr/tsi/verification-server
-RUN cd ${WORK_DIR}
-RUN mvn --batch-mode ${MAVEN_ARGS} install
+# hadolint ignore=SC2086
+RUN mvn --batch-mode --file ${WORK_DIR}/pom.xml ${MAVEN_ARGS}  install
 RUN cp ${WORK_DIR}/target/cwa-verification-server*.jar /usr/tsi/verification-server/verification.jar
 
 FROM gcr.io/distroless/java:11

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR ${WORK_DIR}
 
 RUN mkdir -p /root/.m2 /usr/tsi/verification-server
 RUN cd ${WORK_DIR}
-RUN mvn -B ${MAVEN_ARGS} install
+RUN mvn --batch-mode ${MAVEN_ARGS} install
 RUN cp ${WORK_DIR}/target/cwa-verification-server*.jar /usr/tsi/verification-server/verification.jar
 
 FROM gcr.io/distroless/java:11


### PR DESCRIPTION
same as in https://github.com/corona-warn-app/cwa-server/pull/215

> As all commands in the build stage can be executed with absolute paths, using `WORKDIR` or `cd ${WORK_DIR}` are not necessary. 
> 
> This solves [HaDoLint](https://github.com/hadolint/hadolint) findings [DL3003](https://github.com/hadolint/hadolint/wiki/DL3003) and [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164).

[SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086) finding is ignored as mvn execution will not work as expected if value is quoted.