### PR TITLE
add sonar scan to CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: git fetch --unshallow
     - uses: actions/cache@v1
       env:
         cache-name: m2
@@ -24,7 +25,14 @@ jobs:
       with:
         java-version: 11
     - run: |
-        mvn --batch-mode package
+        mvn --batch-mode package sonar:sonar \
+          -Dsonar.login=$SONAR_TOKEN \
+          -Dsonar.organization=corona-warn-app \
+          -Dsonar.projectKey=corona-warn-app_cwa-verification-server
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        SONAR_HOST_URL: https://sonarcloud.io
     - uses: actions/upload-artifact@v1
       with:
         name: target


### PR DESCRIPTION
**Changes:**

- extend GH actions maven build by `sonar:sonar` goal
- report to https://sonarcloud.io as `corona-warn-app_cwa-verification-server` in org `corona-warn-app`

**Prerequisites:**

- initialize `cwa-verification-server` on [SonarCloud project page](https://sonarcloud.io/projects/create) (install SonarCloud GitHub App)
- define `SONAR_TOKEN` on [project secret settings page](https://github.com/corona-warn-app/cwa-verification-server/settings/secrets)

**Open Topics:**
- use JaCoCos XML report (exec is deprecated)
- clarify usage of parameters in `pom.xml`
 