### PR TITLE
fix GUID_HASH_PATTERN

### DIFF
--- a/src/main/java/app/coronawarn/verification/service/HashingService.java
+++ b/src/main/java/app/coronawarn/verification/service/HashingService.java
@@ -34,7 +34,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class HashingService {
 
-  private static final String GUID_HASH_PATTERN = "[0-9A-Fa-f]{64}";
+  private static final String GUID_HASH_PATTERN = "^[0-9A-Fa-f]{64}$";
   private static final Pattern pattern = Pattern.compile(GUID_HASH_PATTERN);
 
 

--- a/src/test/java/app/coronawarn/verification/service/HashingServiceTest.java
+++ b/src/test/java/app/coronawarn/verification/service/HashingServiceTest.java
@@ -42,18 +42,19 @@ public class HashingServiceTest {
 
   @Test
   public void testValidSha256Hash() {
-    String hash = "523463041ef9ffa2950d8450feb34c88bc8692c40c9cf3c99dcdf75e270229e2";
-    boolean result = hashingService.isHashValid(hash);
 
-    assertTrue(result);
+    assertTrue(hashingService.isHashValid("523463041ef9ffa2950d8450feb34c88bc8692c40c9cf3c99dcdf75e270229e2"));
+    assertTrue(hashingService.isHashValid("0000000000000000000000000000000000000000000000000000000000000000"));
+    assertTrue(hashingService.isHashValid("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
   }
 
   @Test
   public void testInvalidSha256Hash() {
-    String hash = "523463041ef9ffa2950d8z50feb34c88bc8692c40c9cf3c99dcdf75e270229e2";
-    boolean result = hashingService.isHashValid(hash);
 
-    assertFalse(result);
+    assertFalse(hashingService.isHashValid("x23463041ef9ffa2950d8z50feb34c88bc8692c40c9cf3c99dcdf75e270229e2"));
+    assertFalse(hashingService.isHashValid("523463041ef9ffa2950d8z50feb34c88bc8692c40c9cf3c99dcdf75e270229e2"));
+    assertFalse(hashingService.isHashValid("0"));
+    assertFalse(hashingService.isHashValid("0000000000000000000000000000000000000000000000000000000000000000f"));
   }
 
 


### PR DESCRIPTION
The current implementation accepts hashes with more than 64 chars.
To let HashingService.isHashValid() return false on strings with more than 64 chars the pattern should have `^` and `$` included.

Added more tests to illustrate the issue.