### PR TITLE
fix: remove author tags. Closes #62

### DIFF
--- a/src/main/java/app/coronawarn/verification/model/RegistrationToken.java
+++ b/src/main/java/app/coronawarn/verification/model/RegistrationToken.java
@@ -28,8 +28,6 @@ import lombok.NoArgsConstructor;
 
 /**
  * This class represents the registration Token.
- *
- * @author T-Systems International GmbH
  */
 @Schema
 @Data

--- a/src/main/java/app/coronawarn/verification/model/Tan.java
+++ b/src/main/java/app/coronawarn/verification/model/Tan.java
@@ -28,8 +28,6 @@ import lombok.NoArgsConstructor;
 
 /**
  * This class represents the transaction number.
- *
- * @author T-Systems International GmbH
  */
 @Schema
 @Data

--- a/src/main/java/app/coronawarn/verification/model/TeleTan.java
+++ b/src/main/java/app/coronawarn/verification/model/TeleTan.java
@@ -28,8 +28,6 @@ import lombok.NoArgsConstructor;
 
 /**
  * This class represents the tele transaction number (Tele TAN).
- *
- * @author T-Systems International GmbH
  */
 @Schema
 @Data

--- a/src/main/java/app/coronawarn/verification/service/AppSessionService.java
+++ b/src/main/java/app/coronawarn/verification/service/AppSessionService.java
@@ -40,8 +40,6 @@ import org.springframework.stereotype.Component;
 
 /**
  * This class represents the VerificationAppSession service.
- *
- * @author T-Systems International GmbH
  */
 @Slf4j
 @RequiredArgsConstructor


### PR DESCRIPTION
Duplicate information. Copyright holders are referenced in the copyright header of each file.