### PR TITLE
Update architecture-overview.md and default configuration

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -207,7 +207,7 @@ API Endpoint:
 
 1.	Verify registrationToken, if registrationToken is invalid, exit with error HTTP 400
 2.	Verifiy whether the entity AppSession exists for the Registration token
-	1.	If yes, check if TANcounter >= 2
+	1.	If yes, check if TANcounter >= 1
 		1.	If yes, return error HTTP 400
 	1.	If no, return error HTTP 400
 3.	If AppSession.sourceOfTrust == “hashedGUID”
@@ -220,6 +220,7 @@ API Endpoint:
 5.	Persist TAN as entity TAN
 6.	Update entity AppSession, increment TANcounter
 7.	Return TAN string
+
 
 ###	Use Case Create teleTAN
 API Endpoint:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,7 +58,7 @@ tan:
   valid:
     days: 14
 appsession:
-  tancountermax: 2
+  tancountermax: 1
 entities:
   cleanup:
     days: 21

--- a/src/test/java/app/coronawarn/verification/VerificationApplicationTest.java
+++ b/src/test/java/app/coronawarn/verification/VerificationApplicationTest.java
@@ -21,6 +21,7 @@
 
 package app.coronawarn.verification;
 
+import app.coronawarn.verification.config.VerificationApplicationConfig;
 import app.coronawarn.verification.model.HashedGuid;
 import app.coronawarn.verification.model.TestResult;
 import app.coronawarn.verification.domain.VerificationAppSession;
@@ -95,6 +96,9 @@ public class VerificationApplicationTest {
   private VerificationAppSessionRepository appSessionrepository;
   @Autowired
   private ObjectMapper mapper;
+  
+  @Autowired
+  private VerificationApplicationConfig verificationApplicationConfig;
 
   @BeforeEach
   void setUp() {
@@ -187,7 +191,8 @@ public class VerificationApplicationTest {
     log.info("process callGenerateTanWithTanCounterMaximum()");
     appSessionrepository.deleteAll();
     VerificationAppSession appSessionTestData = getAppSessionTestData();
-    appSessionTestData.setTanCounter(2);
+    int tancountermax = verificationApplicationConfig.getAppsession().getTancountermax();
+    appSessionTestData.setTanCounter(tancountermax);
     appSessionrepository.save(appSessionTestData);
 
     mockMvc.perform(post(PREFIX_API_VERSION + "/tan")


### PR DESCRIPTION
reduce maximum number of tans to be created for a reg token to 1