### PR TITLE
change port settings

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     change-log: classpath:db/changelog.yml
 server:
   max-post-size: 10000
+  port: 8082
 feign:
   client:
     config:
@@ -35,7 +36,7 @@ management:
   server:
     ssl:
       enabled: false
-    port: 8081
+    port: 6081
   endpoint:
     info:
       enabled: true


### PR DESCRIPTION
This PR changes port settings for the application and the
management interface.

We changed the application port from tomcat default to 8082. This was
done because the default settings of cwa-verification-portal try
to connect to the verification-sever on port 8082 (see
cwa-verification-portal application.yml key
"cwa-verification-server.url"). So we changed it to match that here.

We changed the management interface port from 8081 to 6081. This was
done to facilitate having it run alongside all other backend components
on the same machine for development and testing. This was not possible,
since they all listen on 8081 for the management interface.
Should this change be accepted, we would like to distribute the other
services management interfaces to different ports as well.