### PR TITLE
fix: unnecessary annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>app.coronawarn.verification</groupId>
   <artifactId>cwa-verification-server</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.3.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>cwa-verification-server</name>


### PR DESCRIPTION
The '@Getter' and '@Setter' Lombok annotations at the beginning of the class make the ones I removed irrelevant because for the first two attributes the annotation "getter" and "setter" are so to say duplicated.