### PR TITLE
Changed lombok version to 1.18.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <spring.boot.version>2.3.1.RELEASE</spring.boot.version>
     <spring-security.version>5.3.3.RELEASE</spring-security.version>
     <spring.cloud.version>Hoxton.SR4</spring.cloud.version>
-    <lombok.version>1.18.12</lombok.version>
+    <lombok.version>1.18.16</lombok.version>
     <liquibase.version>3.10.0</liquibase.version>
     <springdoc.version>1.4.2</springdoc.version>
     <jsonwebtoken.version>0.11.2</jsonwebtoken.version>


### PR DESCRIPTION
Changed the lombok version to 1.18.16 (more information: [https://github.com/rzwitserloot/lombok/releases/tag/v1.18.16](https://github.com/rzwitserloot/lombok/releases/tag/v1.18.16)) to make use of the new fixes. This includes also better support for the new java compiler versions (14 and 15) usefull as a prevention of possible problems, should the Project once switch to a newer Java version.