### PR TITLE
Add Possibility to disable DOB Hash Check in External Test Result Controller

### DIFF
--- a/src/main/java/app/coronawarn/verification/config/VerificationApplicationConfig.java
+++ b/src/main/java/app/coronawarn/verification/config/VerificationApplicationConfig.java
@@ -43,6 +43,8 @@ public class VerificationApplicationConfig {
   private Jwt jwt = new Jwt();
   private Request request = new Request();
 
+  private boolean disableDobHashCheckForExternalTestResult;
+
   /**
    * Configure the Tan with build property values and return the configured parameters.
    */

--- a/src/main/java/app/coronawarn/verification/controller/ExternalTestStateController.java
+++ b/src/main/java/app/coronawarn/verification/controller/ExternalTestStateController.java
@@ -2,6 +2,7 @@ package app.coronawarn.verification.controller;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
+import app.coronawarn.verification.config.VerificationApplicationConfig;
 import app.coronawarn.verification.domain.VerificationAppSession;
 import app.coronawarn.verification.exception.VerificationServerException;
 import app.coronawarn.verification.model.AppSessionSourceOfTrust;
@@ -16,13 +17,11 @@ import app.coronawarn.verification.service.TestResultServerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.validation.Valid;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -68,6 +67,8 @@ public class ExternalTestStateController {
 
   private final FakeDelayService fakeDelayService;
 
+  private final VerificationApplicationConfig config;
+
   /**
    * Returns the test status of the COVID-19 test with cwa-fake header.
    *
@@ -111,7 +112,7 @@ public class ExternalTestStateController {
           testResult.setResponsePadding(RandomStringUtils.randomAlphanumeric(RESPONSE_PADDING_LENGTH));
 
           // Check DOB Hash if present
-          if (appSession.get().getHashedGuidDob() != null) {
+          if (!config.isDisableDobHashCheckForExternalTestResult() && appSession.get().getHashedGuidDob() != null) {
             HashedGuid hashDob = new HashedGuid(appSession.get().getHashedGuidDob());
             TestResult testResultDob = testResultServerService.result(hashDob);
 

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -20,3 +20,4 @@ cwa-testresult-server:
     key-store-password: ${SSL_VERIFICATION_KEYSTORE_PASSWORD}
     trust-store:  ${SSL_VERIFICATION_TRUSTSTORE_PATH}
     trust-store-password: ${SSL_VERIFICATION_TRUSTSTORE_PASSWORD}
+disable-dob-hash-check-for-external-test-result: ${DISABLE_DOB_EXTERNAL_TR}

--- a/src/test/java/app/coronawarn/verification/VerificationApplicationExternalTestWorkaround.java
+++ b/src/test/java/app/coronawarn/verification/VerificationApplicationExternalTestWorkaround.java
@@ -1,0 +1,77 @@
+/*
+ * Corona-Warn-App / cwa-verification
+ *
+ * (C) 2020, T-Systems International GmbH
+ *
+ * Deutsche Telekom AG and all other contributors /
+ * copyright owners license this file to you under the Apache
+ * License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package app.coronawarn.verification;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import app.coronawarn.verification.model.HashedGuid;
+import app.coronawarn.verification.model.RegistrationToken;
+import app.coronawarn.verification.repository.VerificationAppSessionRepository;
+import app.coronawarn.verification.service.TestResultServerService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * This is the test class for the verification application.
+ */
+@Slf4j
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(properties = "disable-dob-hash-check-for-external-test-result=true")
+@ContextConfiguration(classes = VerificationApplication.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("external")
+public class VerificationApplicationExternalTestWorkaround {
+
+  private static final String TOKEN_PADDING = "1";
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private TestResultServerService testResultServerService;
+  @Autowired
+  private VerificationAppSessionRepository appSessionrepository;
+
+  @Test
+  public void callGetTestStateWithDobRegistrationTokenAndTrsRespondsWithDifferentResults() throws Exception {
+    TestUtils.prepareAppSessionTestDataDob(appSessionrepository);
+
+    given(this.testResultServerService.result(new HashedGuid(TestUtils.TEST_GUI_HASH))).willReturn(TestUtils.TEST_LAB_POSITIVE_RESULT);
+    given(this.testResultServerService.result(new HashedGuid(TestUtils.TEST_GUI_HASH_DOB))).willReturn(TestUtils.TEST_LAB_NEGATIVE_RESULT);
+
+    mockMvc.perform(post(TestUtils.PREFIX_API_VERSION + "/testresult").contentType(MediaType.APPLICATION_JSON)
+      .secure(true)
+      .content(TestUtils.getAsJsonFormat(new RegistrationToken(TestUtils.TEST_REG_TOK, TOKEN_PADDING))))
+      .andExpect(status().isOk());
+  }
+
+}

--- a/src/test/java/app/coronawarn/verification/VerificationApplicationInternalTest.java
+++ b/src/test/java/app/coronawarn/verification/VerificationApplicationInternalTest.java
@@ -63,7 +63,7 @@ import org.springframework.test.web.servlet.MockMvc;
  */
 @Slf4j
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(properties = "disable-dob-hash-check-for-external-test-result=true")
 @ContextConfiguration(classes = VerificationApplication.class)
 @AutoConfigureMockMvc
 @ActiveProfiles("internal")


### PR DESCRIPTION
For backward compatibility it is required that the DOB Hash check is disabled in TestResultController. This Workaround needs to be disabled again when all labs have the latest lab software which will alway upload both test ids.