### PR TITLE
Fix: Seperate Unique Constraints for hashed_guid and hashed_guid_dob

### DIFF
--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -23,3 +23,6 @@ databaseChangeLog:
   - include:
       file: changelog/v006-add-index-dob-hashed-guid.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/v007-add-seperate-unique-constraints-for-hashed-guid.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/v007-add-seperate-unique-constraints-for-hashed-guid.yml
+++ b/src/main/resources/db/changelog/v007-add-seperate-unique-constraints-for-hashed-guid.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-seperate-unique-constraints-for-hashed-guid
+      author: f11h
+      changes:
+        - addUniqueConstraint:
+            tableName: app_session
+            columnNames: hashed_guid
+        - addUniqueConstraint:
+            tableName: app_session
+            columnNames: hashed_guid_dob


### PR DESCRIPTION
The current unique constraints only covers entities with both hashed_guid and hashed_guid_dob set. It is still possible to create to entities with same hashed_guid and null vor hashed_guid_dob.